### PR TITLE
Add missing space characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ When you create an object just pass your Array directly
 ### Object
 Crate allows you to define nested objects. I tried to make it as simply as possible to use and reuse existing AR functionality,
 I therefore ask you to reuse the existing serialize functionality. AR#serialize allows you to define your own serialization
-mechanism and we simply reuse that for serializing an AR object. To get serialize working simply create a #dump and #load method 
+mechanism and we simply reuse that for serializing an AR object. To get serialize working simply create a #dump and #load method
 on the class that creates a literal statement that is then used in the SQL. Read up more in this [commit}(https://github.com/crate/crate/commit/16a3d4b3f23996a327f91cdacef573f7ba946017).
 
 I tried to make your guys life easier and created a module that does this automatically for you. Simply make all attributes accessible
@@ -138,11 +138,11 @@ If you think something is missing, either create a pull request
 or log a new issue, so someone else can tackle it.
 Please refer to CONTRIBUTING.rst for further information.
 
-##Maintainer
+## Maintainer
 
 * [CRATE Technology GmbH](http://crate.io)
 * [Christoph Klocker](http://www.vedanova.com), [@corck](http://www.twitter.com/corck)
 
-##License & Copyright
+## License & Copyright
 
 see LICENSE for details.


### PR DESCRIPTION
A space character is needed after the pound character otherwise it won’t
be rendered properly.
