### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ] # macos-latest, windows-latest
-        ruby-version: [ "2.6", "2.7", "3.0", "3.1" ]
+        os: [ "ubuntu-latest" ]
+        ruby-version: [ "2.4" ]
 
     services:
       cratedb:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,14 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
+
+      # Run all jobs to completion (false), or cancel
+      # all jobs once the first one fails (true).
+      fail-fast: false
+
       matrix:
         os: [ "ubuntu-latest" ]
-        ruby-version: [ "2.4" ]
+        ruby-version: [ "2.4", "2.5", "2.6" ]
 
     services:
       cratedb:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Gem Version](https://badge.fury.io/rb/activerecord-crate-adapter.svg)](http://badge.fury.io/rb/activerecord-crate-adapter)
-[![Build Status](https://travis-ci.org/crate/activerecord-crate-adapter.svg?branch=master)](https://travis-ci.org/crate/activerecord-crate-adapter)
+[![Build status](https://github.com/crate/activerecord-crate-adapter/actions/workflows/tests.yml/badge.svg)](https://github.com/crate/activerecord-crate-adapter/actions/workflows/tests.yml)
 [![Code Climate](https://codeclimate.com/github/crate/activerecord-crate-adapter.png)](https://codeclimate.com/github/crate/activerecord-crate-adapter)
 
 The [Crate](http://www.crate.io) adapter for ActiveRecord.

--- a/activerecord-crate-adapter.gemspec
+++ b/activerecord-crate-adapter.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/crate/activerecord-crate-adapter"
   }
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 2.14"
 

--- a/lib/active_record/connection_adapters/crate_adapter.rb
+++ b/lib/active_record/connection_adapters/crate_adapter.rb
@@ -131,7 +131,7 @@ module ActiveRecord
 
       def columns(table_name) #:nodoc:
         cols = @connection.table_structure(table_name).map do |field|
-          name = dotted_name(field[2])
+          name = dotted_name(field[12])
           CrateColumn.new(name, nil, field[4], nil)
         end
         cols

--- a/lib/arel/visitors/crate.rb
+++ b/lib/arel/visitors/crate.rb
@@ -22,8 +22,18 @@
 module Arel
   module Visitors
     class Crate < Arel::Visitors::ToSql
+    end
 
-      private
+    class DepthFirst < Arel::Visitors::Visitor
+      alias :visit_Integer :terminal
+    end
+
+    class Dot < Arel::Visitors::Visitor
+      alias :visit_Integer :visit_String
+    end
+
+    class ToSql < Arel::Visitors::Visitor
+      alias :visit_Integer :literal
     end
   end
 end

--- a/spec/data_types/array_spec.rb
+++ b/spec/data_types/array_spec.rb
@@ -33,7 +33,7 @@ describe "Post#array" do
         t.array :bool_arr, array_type: :boolean
       end
     end
-    ensure_status('yellow')
+    ensure_status('GREEN')
     Post.reset_column_information
   end
 

--- a/spec/data_types/object_spec.rb
+++ b/spec/data_types/object_spec.rb
@@ -31,7 +31,7 @@ describe "User#object" do
                  object_schema: {street: :string, city: :string, phones: {array: :string}, zip: :integer}
       end
     end
-    ensure_status('yellow')
+    ensure_status('GREEN')
     User.reset_column_information
   end
 

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -20,6 +20,8 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 class Post < ActiveRecord::Base
+  self.primary_key = "id"
+
   before_create :set_id
 
   private

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -20,6 +20,8 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 class User < ActiveRecord::Base
+  self.primary_key = "id"
+
   before_create :set_id
 
   serialize :address, Address

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -30,7 +30,7 @@ describe Post do
         t.integer :views
       end
     end
-    ensure_status('yellow')
+    ensure_status('GREEN')
     Post.reset_column_information
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,10 +69,11 @@ end
 # Wait till all table is synced to all shards
 # this should be used after each create_table to prevent flaky tests
 def ensure_status(expected_status)
-  req = Net::HTTP::Get.new("/_cluster/health?wait_for_status=#{expected_status}&timeout=10s")
-  resp = Net::HTTP.new(HOST, PORT)
-  response = resp.start { |http| http.request(req) }
-  actual_status = JSON.parse(response.body)['status']
+  http = Net::HTTP.new(HOST, PORT)
+  request = Net::HTTP::Post.new('/_sql', {'Content-Type' =>'application/json'})
+  request.body = {"stmt": "SELECT DISTINCT health FROM sys.health"}.to_json
+  response = http.request(request)
+  actual_status = JSON.parse(response.body)['rows'].first.first
   raise WrongStatusError, "expected status #{expected_status}, got #{actual_status}" if actual_status != expected_status
 end
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
This makes tests pass for me locally on Ruby 2.4.10. CI uses Ruby >= 2.6 which isn't supported by the used ActiveRecord version (see https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html).

I hope this gives us a more stable starting point for upgrading ActiveRecord in smaller increments.
## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
