### PR TITLE
Dependencies: Update to `crate_ruby-0.2.0`

### DIFF
--- a/activerecord-crate-adapter.gemspec
+++ b/activerecord-crate-adapter.gemspec
@@ -50,5 +50,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('activerecord', '~> 4.1.0')
   spec.add_dependency('arel', '>= 5.0.0')
-  spec.add_dependency('crate_ruby', '~> 0.0.7')
+  spec.add_dependency('crate_ruby', '~> 0.2.0')
 end


### PR DESCRIPTION
Update to crate_ruby version 0.2.0.

-- https://rubygems.org/gems/crate_ruby/versions