### PR TITLE
Update to ActiveRecord 4.2

### DIFF
--- a/activerecord-crate-adapter.gemspec
+++ b/activerecord-crate-adapter.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.13"
 
-  spec.add_dependency('activerecord', '~> 4.1.0')
+  spec.add_dependency('activerecord', '~> 4')
   spec.add_dependency('arel', '>= 5.0.0')
   spec.add_dependency('crate_ruby', '~> 0.2.0')
   # https://github.com/ruby/bigdecimal#which-version-should-you-select

--- a/lib/arel/visitors/crate.rb
+++ b/lib/arel/visitors/crate.rb
@@ -32,7 +32,7 @@ module Arel
       alias :visit_Integer :visit_String
     end
 
-    class ToSql < Arel::Visitors::Visitor
+    class ToSql < Arel::Visitors::Reduce
       alias :visit_Integer :literal
     end
   end

--- a/spec/activerecord/connection_adapters/crate/table_definition_spec.rb
+++ b/spec/activerecord/connection_adapters/crate/table_definition_spec.rb
@@ -31,13 +31,13 @@ describe ActiveRecord::ConnectionAdapters::CrateAdapter::TableDefinition do
     it 'should simply set the key and values' do
       s = {street: :string, city: :string}
       str = td.send(:object_schema_to_string, s)
-      str.should eq "street string, city string"
+      expect(str).to eq("street string, city string")
     end
 
     it 'should simply properly parse an array definition' do
       s = {street: :string, city: :string, phones: {array: :string}}
       str = td.send(:object_schema_to_string, s)
-      str.should eq "street string, city string, phones array(string)"
+      expect(str).to eq("street string, city string, phones array(string)")
     end
 
   end

--- a/spec/data_types/array_spec.rb
+++ b/spec/data_types/array_spec.rb
@@ -22,7 +22,6 @@
 require_relative '../spec_helper'
 
 describe "Post#array" do
-
   before(:all) do
     ActiveRecord::Migration.class_eval do
       create_table :posts do |t|
@@ -43,7 +42,6 @@ describe "Post#array" do
     end
   end
 
-
   describe "#array column type" do
     let(:array) { %w(hot fresh) }
     let(:votes) { [9, 8, 7] }
@@ -53,18 +51,18 @@ describe "Post#array" do
     context 'create' do
       it 'should store and return an array' do
         p = Post.find(post.id)
-        p.tags.should be_a Array
-        p.votes.should be_a Array
-        p.bool_arr.should be_a Array
-        p.tags.should eq array
-        p.votes.should eq votes
-        p.bool_arr.should eq bool_arr
+        expect(p.tags).to be_a(Array)
+        expect(p.votes).to be_a(Array)
+        expect(p.bool_arr).to be_a(Array)
+        expect(p.tags).to eq(array)
+        expect(p.votes).to eq(votes)
+        expect(p.bool_arr).to eq(bool_arr)
       end
 
       it 'should find the post by array value' do
         post = Post.create!(title: 'Arrays are awesome', tags: array, votes: votes)
         refresh_posts
-        Post.where("'fresh' = ANY (tags)").should include(post)
+        expect(Post.where("'fresh' = ANY (tags)")).to include(post)
       end
     end
 
@@ -76,10 +74,8 @@ describe "Post#array" do
         post.update_attributes!(tags: new_tags)
         refresh_posts
         post.reload
-        post.tags.should eq new_tags
+        expect(post.tags).to eq(new_tags)
       end
     end
-
   end
-
 end

--- a/spec/data_types/object_spec.rb
+++ b/spec/data_types/object_spec.rb
@@ -22,7 +22,6 @@
 require_relative '../spec_helper'
 
 describe "User#object" do
-
   before(:all) do
     ActiveRecord::Migration.class_eval do
       create_table :users do |t|
@@ -41,20 +40,17 @@ describe "User#object" do
     end
   end
 
-
   describe "#object column type" do
     let(:address) {Address.new(street: '1010 W 2nd Ave', city: 'Vancouver', phones: ["123", "987"], zip: 6888)}
     let(:user) {@user = User.create!(name: 'Mad Max', address: address)}
 
     it 'should store and return an object' do
       p = User.find(user.id)
-      p.address.should be_a Address
-      p.address.street.should eq address.street
-      p.address.city.should eq address.city
-      p.address.zip.should eq address.zip # without a object schema numbers are converted to strings
-      p.address.phones.should eq address.phones
+      expect(p.address).to be_a(Address)
+      expect(p.address.street).to eq(address.street)
+      expect(p.address.city).to eq(address.city)
+      expect(p.address.zip).to eq(address.zip) # without a object schema numbers are converted to strings
+      expect(p.address.phones).to eq(address.phones)
     end
-
   end
-
 end

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -24,6 +24,8 @@ class Post < ActiveRecord::Base
 
   before_create :set_id
 
+  attr_accessor :title, :views
+
   private
 
   def set_id

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -22,7 +22,6 @@
 require_relative '../spec_helper'
 
 describe Post do
-
   before(:all) do
     ActiveRecord::Migration.class_eval do
       create_table :posts do |t|
@@ -45,14 +44,13 @@ describe Post do
   context 'initialization' do
     it 'should initialize a post object with all columns' do
       post = Post.new(params)
-      post.should be_a(Post)
-      post.title.should eq "Crate rocks"
-      post.views.should eq 10000
+      expect(post).to be_a(Post)
+      expect(post.title).to eq("Crate rocks")
+      expect(post.views).to eq(10000)
     end
   end
 
   context 'persistance' do
-
     before do
       @post = Post.create!(params)
     end
@@ -62,22 +60,20 @@ describe Post do
     end
 
     it 'should persist the record to the database' do
-      @post.persisted?.should eq true
+      expect(@post.persisted?).to be(true)
       refresh_posts
-      Post.count.should eq 1
+      expect(Post.count).to eq(1)
     end
-
   end
 
   context 'deletion' do
-
     before do
       @post = Post.create!(params)
     end
 
     it 'should destroy the record to the database' do
       @post.destroy
-      Post.where(id: @post.id).should be_empty
+      expect(Post.where(id: @post.id)).to be_empty
     end
   end
 
@@ -93,28 +89,27 @@ describe Post do
     context 'find' do
       it 'should find the crated record' do
         post = Post.where(id: @post.id).first
-        post.id.should eq(@post.id)
+        expect(post.id).to eq(@post.id)
       end
 
       it 'should find the crated record by title' do
         refresh_posts
-        Post.where(title: @post.title).count.should eq 1
+        expect(Post.where(title: @post.title).count).to be(1)
         post = Post.where(title: @post.title).first
-        post.id.should eq(@post.id)
+        expect(post.id).to eq(@post.id)
       end
     end
 
     context 'update' do
       it 'should update the record' do
         @post.update_attributes(title: 'Crate Dope')
-        @post.reload.title.should eq('Crate Dope')
+        expect(@post.reload.title).to eq('Crate Dope')
       end
 
     end
   end
 
   describe 'sql input sanitization' do
-
     before do
       @post = Post.create!(params)
     end
@@ -125,16 +120,13 @@ describe Post do
 
     it 'should not return all records but sanitize string' do
       sql = Post.where(id: "#{@post.id} or 1=1").to_sql
-      sql.should match(/'#{@post.id} or 1=1'/)
+      expect(sql).to match(/'#{@post.id} or 1=1'/)
     end
 
     it 'should not drop the table but sanitize string' do
       Post.where(id: "#{@post.title}; DROP TABLE POST")
       refresh_posts
-      Post.last.id.should eq @post.id
+      expect(Post.last.id).to eq(@post.id)
     end
-
   end
-
 end
-


### PR DESCRIPTION
Baby steps, trying to update to the most recent ActiveRecord 4 series here, which is currently 4.2.11.3. Right now, it breaks with `<module:Visitors>': superclass mismatch for class ToSql (TypeError)`. Can you help here, @hammerhead?

```ruby
/home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/lib/arel/visitors/crate.rb:35:in `<module:Visitors>': superclass mismatch for class ToSql (TypeError)
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/lib/arel/visitors/crate.rb:23:in `<module:Arel>'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/lib/arel/visitors/crate.rb:22:in `<top (required)>'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/vendor/bundle/ruby/2.4.0/gems/activesupport-4.2.11.3/lib/active_support/dependencies.rb:274:in `require'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/vendor/bundle/ruby/2.4.0/gems/activesupport-4.2.11.3/lib/active_support/dependencies.rb:274:in `block in require'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/vendor/bundle/ruby/2.4.0/gems/activesupport-4.2.11.3/lib/active_support/dependencies.rb:240:in `load_dependency'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/vendor/bundle/ruby/2.4.0/gems/activesupport-4.2.11.3/lib/active_support/dependencies.rb:274:in `require'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/lib/arel/arel_crate.rb:23:in `<top (required)>'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/vendor/bundle/ruby/2.4.0/gems/activesupport-4.2.11.3/lib/active_support/dependencies.rb:274:in `require'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/vendor/bundle/ruby/2.4.0/gems/activesupport-4.2.11.3/lib/active_support/dependencies.rb:274:in `block in require'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/vendor/bundle/ruby/2.4.0/gems/activesupport-4.2.11.3/lib/active_support/dependencies.rb:240:in `load_dependency'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/vendor/bundle/ruby/2.4.0/gems/activesupport-4.2.11.3/lib/active_support/dependencies.rb:274:in `require'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/lib/active_record/connection_adapters/crate_adapter.rb:25:in `<top (required)>'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/lib/activerecord-crate-adapter.rb:22:in `require'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/lib/activerecord-crate-adapter.rb:22:in `<top (required)>'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/spec/spec_helper.rb:24:in `require'
	from /home/runner/work/activerecord-crate-adapter/activerecord-crate-adapter/spec/spec_helper.rb:24:in `<top (required)>'
```

